### PR TITLE
GH-48 - Switch CI to Gihtub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,6 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,43 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        exclude:
+          - ruby-version: 2.3.8
+            gemfile: gemfiles/activesupport_6.gemfile
+          - ruby-version: 2.4.10
+            gemfile: gemfiles/activesupport_6.gemfile
+        gemfile:
+          - gemfiles/activesupport_5.gemfile
+          - gemfiles/activesupport_6.gemfile
+        ruby-version:
+          - 2.3.8
+          - 2.4.10
+          - 2.5.8
+          - 2.6.6
+          - 2.7.2
+          - '3.0.0' # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake spec_all

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,10 +25,11 @@ jobs:
         ruby-version:
           - 2.3.8
           - 2.4.10
-          - 2.5.8
-          - 2.6.6
-          - 2.7.2
-          - '3.0.0' # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
### What

Set up a Github Actions workflow to build and run tests for the project.

### Why

* travis-ci.org ~is migrating to travis.com soon~ has migrated to travis-ci.com
* Docker is limiting image pulls via current Travis builds
* Github Actions is built in to Github projects like runbook

Relates to #48

Opening this here to see if it will run the Github Actions workflow.